### PR TITLE
Diehl's Method for Effective Charge

### DIFF
--- a/src/NanoParticle.cpp
+++ b/src/NanoParticle.cpp
@@ -305,8 +305,8 @@ void NanoParticle::compute_effective_charge(int &num, vector<int> &condensedIons
     int condensedCountThisStep = 0;
     //  Assess number of condensed ions this step, add it to global list for all steps (after equilibrium):
     for (unsigned int i = 0; i < ion.size(); i++)
-        if(ion[i].electrostaticPE <= -1*((4.0/3.0)*ion[i].ke)) condensedCountThisStep++;
-        //if(ion[i].electrostaticPE <= -1*((4.0/3.0)*1.5)) condensedCountThisStep++;
+        //if(ion[i].electrostaticPE <= -1*((4.0/3.0)*ion[i].ke)) condensedCountThisStep++;  // ion-specific method
+        if(ion[i].electrostaticPE <= -1*((4.0/3.0)*1.5)) condensedCountThisStep++;          // avg KE method
 
     condensedIonsPerStep.push_back(condensedCountThisStep);
 

--- a/src/NanoParticle.h
+++ b/src/NanoParticle.h
@@ -65,6 +65,7 @@ public:
     double mean_sep_out;        // mean separation outside
     int number_of_vertices;    // number of points used to discretize the interface
     double bare_charge;        // bare charge on the membrane (interface)
+    double effective_charge;    // effective charge after ion condensation, salt adduction
     double area_np;        // area of the nano particle
     bool POLARIZED;        // is the nanoparticle polarized; depends on ein, eout
     bool RANDOMIZE_ION_FEATURES;    // are selections randomized
@@ -106,6 +107,9 @@ public:
 
     // compute density profile
     virtual void compute_density_profile();
+
+    // compute effective charge
+    virtual void compute_effective_charge(int &, vector<int> &, vector<PARTICLE> &, NanoParticle *, CONTROL &);
 
     // compute final density profile
     virtual void compute_final_density_profile();

--- a/src/NanoParticleSphere.h
+++ b/src/NanoParticleSphere.h
@@ -54,5 +54,6 @@ public:
     //print number of bins used
     void printBinSize() ;
 
+
 };
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -165,7 +165,7 @@ void make_movie(int num, vector<PARTICLE> &ion, NanoParticle *nanoParticle) {
         outdump << -nanoParticle->box_radius << "\t" << nanoParticle->box_radius << endl;
         outdump << -nanoParticle->box_radius << "\t" << nanoParticle->box_radius << endl;
         outdump << -nanoParticle->box_radius << "\t" << nanoParticle->box_radius << endl;
-        outdump << "ITEM: ATOMS index type x y z" << endl;
+        outdump << "ITEM: ATOMS index type x y z ES KE" << endl;
         string type;
         for (unsigned int i = 0; i < ion.size(); i++) {
             if (ion[i].valency > 0)
@@ -173,7 +173,8 @@ void make_movie(int num, vector<PARTICLE> &ion, NanoParticle *nanoParticle) {
             else
                 type = "-1";
             outdump << setw(6) << i << "\t" << type << "\t" << setw(8) << ion[i].posvec.x << "\t" << setw(8)
-                    << ion[i].posvec.y << "\t" << setw(8) << ion[i].posvec.z << endl;
+                    << ion[i].posvec.y << "\t" << setw(8) << ion[i].posvec.z << "\t" << ion[i].electrostaticPE
+                    << "\t" << ion[i].ke << endl;
         }
         outdump.close();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
             ("cpmd_steps,S", value<int>(&cpmdremote.steps)->default_value(50000), "steps used in cpmd")
             ("fmd_eqm,p", value<int>(&fmdremote.hiteqm)->default_value(100), "production begin (fmd)")
             ("cpmd_eqm,P", value<int>(&cpmdremote.hiteqm)->default_value(10000), "production begin (cpmd)")
-            ("fmd_freq,f", value<int>(&fmdremote.freq)->default_value(100), "sample frequency (fmd)")
+            ("fmd_freq,f", value<int>(&fmdremote.freq)->default_value(10), "sample frequency (fmd)")
             ("cpmd_freq,F", value<int>(&cpmdremote.freq)->default_value(100), "sample frequency (cpmd)")
             ("fmd_verify,y", value<int>(&fmdremote.verify)->default_value(0), "verify (fmd)")
             ("cpmd_verify,Y", value<int>(&cpmdremote.verify)->default_value(10000), "verify (cpmd)")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ unsigned int extraElementsMesh;
 mpi::environment env;
 mpi::communicator world;
 
+vector<int> condensedIonsPerStep; // Number of condensed ions per step (after equilibrium) at specified frequency
 
 using namespace boost::program_options;
 
@@ -136,7 +137,7 @@ int main(int argc, char *argv[]) {
             ("cpmd_steps,S", value<int>(&cpmdremote.steps)->default_value(50000), "steps used in cpmd")
             ("fmd_eqm,p", value<int>(&fmdremote.hiteqm)->default_value(100), "production begin (fmd)")
             ("cpmd_eqm,P", value<int>(&cpmdremote.hiteqm)->default_value(10000), "production begin (cpmd)")
-            ("fmd_freq,f", value<int>(&fmdremote.freq)->default_value(10), "sample frequency (fmd)")
+            ("fmd_freq,f", value<int>(&fmdremote.freq)->default_value(100), "sample frequency (fmd)")
             ("cpmd_freq,F", value<int>(&cpmdremote.freq)->default_value(100), "sample frequency (cpmd)")
             ("fmd_verify,y", value<int>(&fmdremote.verify)->default_value(0), "verify (fmd)")
             ("cpmd_verify,Y", value<int>(&cpmdremote.verify)->default_value(10000), "verify (cpmd)")
@@ -204,12 +205,22 @@ int main(int argc, char *argv[]) {
     // make interface
     nanoParticle->set_up(salt_conc_in, salt_conc_out, salt_valency_in, salt_valency_out, total_gridpoints,
                          box_radius / unitlength);    // set up properties inside and outside the interface
-    nanoParticle->put_counterions(counterion, counterion_valency, counterion_diameter,
-                                  ion);                    // put counterions	Note: ion contains all ions
-    nanoParticle->put_saltions_inside(saltion_in, salt_valency_in, salt_conc_in, saltion_diameter_in,
-                                      ion);                // put salt ions inside
-    nanoParticle->put_saltions_outside(saltion_out, salt_valency_out, salt_conc_out, saltion_diameter_out,
-                                       ion);            // put salt ions outside
+
+    // If running a standard simulation (charged particle and/or with salt) populate the ions:
+    if (abs(nanoparticle_bare_charge) > 0)
+        nanoParticle->put_counterions(counterion, counterion_valency, counterion_diameter, ion);                    // put counterions	Note: ion contains all ions
+    if (salt_conc_in > 0)
+        nanoParticle->put_saltions_inside(saltion_in, salt_valency_in, salt_conc_in, saltion_diameter_in, ion);                // put salt ions inside
+    if (salt_conc_out > 0)
+        nanoParticle->put_saltions_outside(saltion_out, salt_valency_out, salt_conc_out, saltion_diameter_out, ion);            // put salt ions outside
+
+    //  If the charge is set to zero (for testing), insert test two test ions at chosen positions:
+    /*if (nanoparticle_bare_charge == 0)
+    {
+        ion.push_back(PARTICLE(int(ion.size()) + 1, counterion_diameter, counterion_valency, counterion_valency * 1.0, 1.0, eout, VECTOR3D(45,0,0)));
+        ion.push_back(PARTICLE(int(ion.size()) + 1, counterion_diameter, counterion_valency, counterion_valency * 1.0, 1.0, eout, VECTOR3D(46,0,0)));
+    }*/
+
     nanoParticle->discretize(s);                                // discretize interface
 
     // if dielectric environment inside and outside NP are different, NPs get polarized
@@ -289,9 +300,10 @@ int main(int argc, char *argv[]) {
     // write to files
     // initial configuration
     ofstream initial_configuration("outfiles/initialconfig.dat");
-    for (unsigned int i = 0; i < ion.size(); i++)
-        initial_configuration << "ion" << setw(5) << ion[i].id << setw(15) << "charge" << setw(5) << ion[i].q
-                              << setw(15) << "position" << setw(15) << ion[i].posvec << endl;
+    if (world.rank() == 0)
+        for (unsigned int i = 0; i < ion.size(); i++)
+            initial_configuration << "ion" << setw(5) << ion[i].id << setw(15) << "charge" << setw(5) << ion[i].q
+                                  << setw(15) << "position" << setw(15) << ion[i].posvec << endl;
     initial_configuration.close();
 
     // initial density
@@ -351,15 +363,14 @@ int main(int argc, char *argv[]) {
     } else if (world.rank() == 0)
         cout << "no induced charges; simulation will proceed using simple MD" << endl;
 
-    if (world.rank() == 0) {
+    ofstream induced_density("outfiles/induced_density.dat");
+    if (world.rank() == 0)
         // result of fmd
-        ofstream induced_density("outfiles/induced_density.dat");
         for (unsigned int k = 0; k < s.size(); k++)
             induced_density << k + 1 << setw(15) << s[k].theta << setw(15) << s[k].phi << setw(15) << s[k].w << setw(15)
                             << s[k].wmean << endl;
-        induced_density.close();
-    }
 
+    induced_density.close();
     // prepare for cpmd : make real and fake baths
 
     vector<THERMOSTAT> real_bath;
@@ -390,6 +401,7 @@ int main(int argc, char *argv[]) {
         cout << "Number of chains for real system" << setw(3) << real_bath.size() - 1 << endl;
         cout << "Number of chains for fake system" << setw(3) << fake_bath.size() - 1 << endl;
     }
+
     // Car-Parrinello Molecular Dynamics
     cpmd(ion, s, nanoParticle, real_bath, fake_bath, fmdremote, cpmdremote);
 

--- a/src/particle.h
+++ b/src/particle.h
@@ -25,6 +25,7 @@ class PARTICLE
       ar & velvec;
       ar & forvec;
       ar & pe;
+      ar & electrostaticPE;
       ar & ke;
       ar & energy;
     }
@@ -42,6 +43,7 @@ class PARTICLE
   VECTOR3D velvec;	// velocity vector of the particle
   VECTOR3D forvec;	// force vector on the particle
   double pe;		// potential energy
+  double electrostaticPE;  // the ES component of the PE
   long double ke;	// kinetic energy
   double energy;	// energy
   

--- a/src/penergies.cpp
+++ b/src/penergies.cpp
@@ -167,6 +167,10 @@ double energy_functional(vector<VERTEX> &s, vector<PARTICLE> &ion, NanoParticle 
         for (k = 0; k < ind_energy.size(); k++)
             ind_ind = ind_ind + ind_energy[k];
 
+        //  Assess the electrostatic component of the PE for each ion (for use in Diehl's Method):
+        for(unsigned int i = 0; i < ion_energy.size(); i++)
+            ion[i].electrostaticPE = scalefactor * ion_energy[i];
+
         // electrostatic potential energy
         potential = (ion_ion + ind_ind) * scalefactor;
     } else    // if not POLARIZED
@@ -193,6 +197,9 @@ double energy_functional(vector<VERTEX> &s, vector<PARTICLE> &ion, NanoParticle 
                 ion_energy[i-lowerBoundIons] = fqq + insum;
             }
 
+        //  Assess the electrostatic component of the PE for each ion (for use in Diehl's Method):
+        for(unsigned int i = 0; i < ion_energy.size(); i++)
+            ion[i].electrostaticPE = scalefactor * ion_energy[i];
 
         double ion_ion = 0;
         for (unsigned int i = 0; i < ion_energy.size(); i++)


### PR DESCRIPTION
This implements Diehl's method for computing the effective charge.  This requires comparing the ratio of individual ions' electrostatic potential (U) and kinetic energies (KE) - no NP proximity criterion is present.  This means it requires the energy functional be re-evaluated every step that Diehl's method is calculated - which is set to be every production step during which the RDF is also being calculated.  Both a method using the individual ion (U) & (KE) are implemented, but the one using individual ion's KE is commented out within the function.  The default is to use the average KE.  It seems to depend on the bare charge density which one gives the better result.

**Output File Changes:**

Movie file:  two columns have been added to the movie file, per-ion (U) and (KE).  This allows visualization of the (U) and (KE) by color (and scatter plot, etc.) in Ovito easily.  However, the (U) is only updated each time the energy functional is re-evaluated, so it's only precise at the first step of that interval.  I think the default interval is 1000 steps.

New file:  a time-series file is generated, giving the number of condensed ions at each step (post-equilibrium).  It's this time-series that is averaged over to produce the mean number of condensed ions and the effective charge.